### PR TITLE
Fix link to Advanced Concepts

### DIFF
--- a/scenarios/prompt_engineering/02_Sample_Scenarios/02_Information_Extraction.md
+++ b/scenarios/prompt_engineering/02_Sample_Scenarios/02_Information_Extraction.md
@@ -126,7 +126,7 @@ According to the traffic laws of California, Jane Doe was at fault for running a
 
 **IMPORTANT NOTE**: You may have to increase the 'Max length (tokens)' parameter if the output gets cut off (you'll probably need to increase it to 500+ tokens).
 
-Please note how comprehensive the output is. You'll most likely want to control the format of the output to fit your needs and existing systems. For this, One Shot or Few Shots learning are great techniques to consider. See [Advanced Concepts](../02_Advanced_Concepts.md) for more information.
+Please note how comprehensive the output is. You'll most likely want to control the format of the output to fit your needs and existing systems. For this, One Shot or Few Shots learning are great techniques to consider. See [Advanced Concepts](../03_Advanced_Concepts.md) for more information.
 
 ---
 


### PR DESCRIPTION
Then link to the Advanced Concepts topic is wrong within the Information Extraction docs.