### PR TITLE
Custom data scenario bugfix

### DIFF
--- a/scenarios/openai_on_custom_dataset/SemiAutomated.md
+++ b/scenarios/openai_on_custom_dataset/SemiAutomated.md
@@ -77,6 +77,8 @@ To make it easy for the labs, the sample document has already been chunked and p
         AFR_ENDPOINT="<YOUR Azure Form Recognizer Service API EndPoint>"
         AFR_API_KEY="<YOUR Azure Form Recognizer API Key>"
         INDEX_NAME="azure-ml-docs"
+        FILE_URL="https://github.com/microsoft/OpenAIWorkshop/raw/main/scenarios/data/azure-machine-learning-2-500.pdf"
+        LOCAL_FOLDER_PATH=""
 
 *   The document processing, chunking, indexing can all be scripted using any preferred language. 
     This repo uses Python. Run the below script to create search index, add semantic configuration and populate few sample documents from Azure doc. 

--- a/scenarios/openai_on_custom_dataset/deploy/azure-deploy-funcapp-storage-existing-vnet.json
+++ b/scenarios/openai_on_custom_dataset/deploy/azure-deploy-funcapp-storage-existing-vnet.json
@@ -322,7 +322,7 @@
             },
             {
                 "name": "INDEX_NAME",
-                "value": "azure-aml-docs"
+                "value": "azure-ml-docs"
     
             },
             {

--- a/scenarios/openai_on_custom_dataset/deploy/azure-deploy-funcapp-storage-new-vnet.json
+++ b/scenarios/openai_on_custom_dataset/deploy/azure-deploy-funcapp-storage-new-vnet.json
@@ -391,7 +391,7 @@
             },
             {
                 "name": "INDEX_NAME",
-                "value": "azure-aml-docs"
+                "value": "azure-ml-docs"
     
             },
             {

--- a/scenarios/openai_on_custom_dataset/deploy/azure-deploy-resources.json
+++ b/scenarios/openai_on_custom_dataset/deploy/azure-deploy-resources.json
@@ -178,7 +178,7 @@
             },
             {
                 "name": "INDEX_NAME",
-                "value": "azure-aml-docs"
+                "value": "azure-ml-docs"
     
             },
             {

--- a/scenarios/openai_on_custom_dataset/deploy/azure-deploy.json
+++ b/scenarios/openai_on_custom_dataset/deploy/azure-deploy.json
@@ -188,7 +188,7 @@
             },
             {
                 "name": "INDEX_NAME",
-                "value": "azure-aml-docs"
+                "value": "azure-ml-docs"
     
             },
             {


### PR DESCRIPTION
This PR includes two bugfixes for the [custom dataset scenario](https://github.com/microsoft/OpenAIWorkshop/tree/main/scenarios/openai_on_custom_dataset).
			
1. As described in [Issue #90](https://github.com/microsoft/OpenAIWorkshop/issues/90), the search index name is inconsistent between the function app and index creation scripts. Updating all references to use the "azure-ml-docs" index name.
2. search-indexer.py requires "FILE_URL" & "LOCAL_FOLDER_PATH" to be set in secrets.env, but this isn't currently called out in the sem-automated instructions.