### PR TITLE
Add durable/long-running agent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Welcome to the official repository for the Microsoft AI Agentic Workshop! This r
   
 - **Configurable LLM Backend:** Use the latest Azure OpenAI GPT models (e.g., GPT-4.1, GPT-4o).  
 - **MCP Server Integration:** Advanced tools to enhance agent orchestration and capabilities.  
-- **A2A (Agent-to-Agent) Protocol Support:** Enables strict cross-domain, black-box multi-agent collaboration using [Google's A2A protocol](https://github.com/google-a2a/A2A).
+- **A2A (Agent-to-Agent) Protocol Support:** Enables strict cross-domain, black-box multi-agent collaboration using [Google's A2A protocol](https://github.com/google-a2a/A2A). [Learn more &rarr;](agentic_ai/agents/semantic_kernel/multi_agent/a2a).  
+- **Durable Agent Pattern:** Includes a demo of a robust agent that persists its state, survives restarts, and manages long-running workflows. [Learn more &rarr;](agentic_ai/agents/autogen/durable_agent/README.md)  
 - **Flexible Agent Architecture:**  
   - Supports single-agent, multi-agent, or reflection-based agents (selectable via `.env`).  
   - Agents can self-loop, collaborate, reflect, or take on dynamic roles as defined in modules.  
@@ -54,15 +55,6 @@ Welcome to the official repository for the Microsoft AI Agentic Workshop! This r
   
 ---  
   
-## 🆕 A2A (Agent-to-Agent) Cross-Domain Demo  
-  
-This repository now supports a strict cross-domain multi-agent scenario using the A2A protocol, enabling message-driven, black-box collaboration between a customer-service agent and a logistics agent.  
-  
-**A2A Example Included:**    
- See [`agentic_ai/agents/semantic_kernel/multi_agent/a2a`](agentic_ai/agents/semantic_kernel/multi_agent/a2a).  
-  
----  
-
 ## Contributing  
   
 Please review our [Code of Conduct](./CODE_OF_CONDUCT.md) and [Security Guidelines](./SECURITY.md) before contributing.  

--- a/SETUP.md
+++ b/SETUP.md
@@ -142,6 +142,12 @@ COSMOSDB_CONTAINER_NAME="state_store"
 - **Fill in the Cosmos variables** ➜ the app automatically switches to an Azure Cosmos DB container with a hierarchical partition-key (`/tenant_id + /id`) so chat history survives restarts and scales across instances.  
   
 > If neither `COSMOSDB_KEY` nor the AAD credential set is provided, the code silently falls back to the in-memory store.  
+> **Important:**    
+> If you choose Cosmos DB and use Azure AD service-principal authentication, you must grant the service principal a custom role for data plane (read/write) access in Cosmos DB.    
+> See: [Grant data plane access using custom roles in Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/how-to-grant-data-plane-access?tabs=custom-definition%2Ccsharp&pivots=azure-interface-cli)  
+>  
+> Without this role, the application will not be able to access or persist chat history in Cosmos DB using Azure AD authentication.  
+
 #### Make sure your Azure resources are configured to use the correct model deployment names, endpoints, and API versions.  
   
 ---  

--- a/agentic_ai/agents/autogen/durable_agent/README.md
+++ b/agentic_ai/agents/autogen/durable_agent/README.md
@@ -1,0 +1,110 @@
+# Durable-Agent Demo 🚀  
+  
+> An experiment in making **AI agents durable** – i.e. able to  
+> preserve state, survive crashes / restarts and handle long-running  
+> workflows without blocking.  
+  
+---  
+  
+## 1.  Why “durable” agents?  
+  
+Normal conversational agents keep all their short-term memory **in RAM**.  
+If the process dies, the whole context is lost.  Durable agents, in contrast, are designed to:  
+  
+1. **Persist state** – every turn they write their internal state to an external store (Cosmos DB in Azure or an in-memory dict for local runs).  
+2. **Resume seamlessly** – on the next request they reload that state and continue the conversation exactly where they left off.  
+3. **Survive long-running work** – they can kick off background jobs or remote orchestrations (Azure Durable Functions, workflows, etc.), go completely idle, and later integrate the result back into the conversation once it is available.  
+  
+These three abilities together make a durable agent *resilient*, *tolerant to infra hiccups*, and *suitable for complex, multi-step business flows*.  
+  
+---  
+  
+## 2.  High-level architecture  
+  
+```mermaid  
+flowchart TD  
+    A["Streamlit UI"]  -- REST --> B["FastAPI Backend"]  
+    subgraph Backend  
+        B --> C["Durable Agent<br/>Round-Robin<br/>Group Chat"]  
+        C -- "load / save" --> D["State Store<br/>CosmosDB/dict"]  
+        C -- "calls" --> E["MCP & Local Tools"]  
+        C -- "schedules" --> F["Background Worker<br/>(thread/Durable Fn.)"]  
+        F -- "update" --> D  
+    end  
+```
+
+## 3. Sequence of a long-running operation
+```mermaid
+sequenceDiagram  
+    participant U as User (UI)  
+    participant BE as FastAPI  
+    participant AG as Durable Agent  
+    participant BG as Background Job  
+    participant SS as State Store  
+  
+    U->>BE: "Activate line …"  
+    BE->>AG: chat(task)  
+    AG->>AG: tool call activate_new_line  
+    AG->>BG: spawn thread & return  
+    AG->>SS: save state  
+    AG->>BE: "Task scheduled, please wait…"  
+    BE->>U: immediate reply  
+  
+    Note over BG: ~long running task  
+    BG-->>SS: append result message  
+  
+    U->>BE: "Is it done?"  
+    BE->>AG: chat(next turn)  
+    AG->>SS: load state (+result)  
+    AG-->>BE: "✅ Done, line is active."  
+    BE-->>U: final reply      
+```
+## 4. Current Demo – What is Implemented?  
+  
+| Capability                           | Status | Notes                                                                                                  |  
+|---------------------------------------|:------:|--------------------------------------------------------------------------------------------------------|  
+| Resilient state persistence           |   ✅   | Cosmos DB or in-mem dict                                                                               |  
+| Autogen agent re-hydration            |   ✅   | Agent loads TeamState on every request                                                                 |  
+| Long-running tool scheduling          |   ✅   | Simulated via Python threading (20 s sleep)                                                            |  
+| Result injection after completion     |   ✅   | Worker edits saved state (`FunctionExecutionResultMessage`)                                            |  
+| Push notifications to UI (SSE)        |   ♻️   | Optional add-on shown in docs                                                                          |  
+| Integration with Azure Durable Fn.    |   🟡   | Conceptually supported; not wired-up in repo                                                           |  
+| Full error-handling / retries         |   🟡   | Basic happy-path only                                                                                  |  
+  
+---  
+  
+## 5. Code Hotspots  
+  
+- **agents/base_agent.py**    
+  Abstract helper that reads env-vars and exposes `chat_async`.  
+  
+- **agents/durable_agent/loop_agent.py**    
+  - Builds an Autogen `RoundRobinGroupChat` with one `AssistantAgent`.  
+  - Registers normal MCP tools and a custom long-running tool `activate_new_line`.  
+  - Spawns a background thread that, after the fake 20 s delay, loads the saved `TeamState`, injects a synthetic `ToolCallRequestEvent` plus matching `ToolCallExecutionEvent`, and rewrites the state.  
+  
+- **utils/CosmosDBStateStore**    
+  Thin wrapper around Cosmos container ⇒ “dict-like” API.  
+  
+- **backend.py**    
+  FastAPI endpoints:    
+  `/chat`, `/history/{id}`, `/reset_session`.    
+  (Optional) `/events/{id}` for Server-Sent Events push.  
+  
+---  
+  
+## 6. Extending the Pattern  
+  
+- Swap the background threading code for Azure Durable Functions or Azure Container Apps Jobs – post the final status to the same state store key.  
+- Support multiple parallel long-running calls by including a unique tool `call_id` per job; each worker injects its own result message.  
+- Add retry metadata (e.g. “attempt #”, “next ETA”) inside the state so the agent can reason about failures and keep the user informed.  
+- Implement push UI (SSE / WebSockets) for real-time updates without polling.  
+  
+---  
+  
+## 7. Limitations & Next Steps  
+  
+- Persisted messages grow indefinitely – add TTL / pruning.  
+- Background thread approach works only for single-process deployments – use external orchestrators in prod.  
+- No security model yet (authN / authZ on APIs, encrypt Cosmos).  
+

--- a/agentic_ai/agents/autogen/durable_agent/loop_agent.py
+++ b/agentic_ai/agents/autogen/durable_agent/loop_agent.py
@@ -1,0 +1,230 @@
+import os  
+from dotenv import load_dotenv  
+from typing import Any, Dict
+from autogen_agentchat.agents import AssistantAgent  
+from autogen_agentchat.teams import RoundRobinGroupChat  
+from autogen_agentchat.conditions import TextMessageTermination  
+from autogen_core import CancellationToken  
+from autogen_ext.models.openai import AzureOpenAIChatCompletionClient  
+from autogen_ext.tools.mcp import StreamableHttpServerParams, mcp_server_tools  
+from agents.base_agent import BaseAgent    
+import threading, asyncio, uuid
+from datetime import datetime  
+import json
+
+from autogen_core.models import FunctionExecutionResult, FunctionExecutionResultMessage
+load_dotenv()  
+
+# NEW imports
+import asyncio, threading, time
+from typing import Any, Dict
+
+from autogen_core.models import (
+    FunctionExecutionResult,
+    FunctionExecutionResultMessage,
+)
+
+# ---------------------------------------------------------------------
+# 1.  User-visible tool (LLM will call this)
+# ---------------------------------------------------------------------
+async def activate_new_line(customer_id: str, phone_number: str) -> str:
+    """
+    Handle the activation of a new line for a customer.
+
+    The operation is long-running (~20 s).  
+    Immediately acknowledge that the task was scheduled; the customer will be
+    notified once activation is complete.
+    """
+    # Body never executed – see wrapper registration further below.
+# ───────────────────────────────────────────────────────────────────────
+# 2)  internal helper – does the real scheduling
+# ───────────────────────────────────────────────────────────────────────
+# ---------------------------------------------------------------------
+# 2.  Internal helper, does the real scheduling
+# ---------------------------------------------------------------------
+async def _activate_new_line_impl(
+    customer_id: str,
+    phone_number: str,
+    *,
+    __session_id__: str,
+    __state_store__: Dict[str, Any],
+) -> str:
+    """
+    Internal helper invoked by wrapper; identical semantics but with context.
+    """
+
+    # ── background job that will run AFTER 20 s ──────────────────────
+
+
+    async def _post_completion() -> None:
+        await asyncio.sleep(20)                              # 1️⃣ simulate work
+
+        # 2️⃣ Load the persisted TeamState dict
+        team_state: dict[str, Any] | None = __state_store__.get(__session_id__)
+        if team_state is None:
+            return                                           # session was wiped
+
+        # 3️⃣ Compute helper refs
+        ai_ctx   = team_state["agent_states"]["ai_assistant"]["agent_state"]["llm_context"]["messages"]
+        thread   = team_state["agent_states"]["RoundRobinGroupChatManager"]["message_thread"]
+
+        # 4️⃣ Build a NEW tool-call id & arguments
+        new_call_id = f"call_{uuid.uuid4().hex}"
+        arguments_json = json.dumps(
+            {"customer_id": customer_id, "phone_number": phone_number}
+        )
+
+        # 5️⃣ Tool-CALL message  (AssistantMessage / ToolCallRequestEvent)
+        call_msg_assistant = {
+            "content": [
+                {
+                    "id": new_call_id,
+                    "arguments": arguments_json,
+                    "name": "activate_new_line_result_update",
+                }
+            ],
+            "thought": None,
+            "source": "ai_assistant",
+            "type": "AssistantMessage",
+        }
+        call_msg_thread = {
+            "id": str(uuid.uuid4()),
+            "source": "ai_assistant",
+            "models_usage": None,
+            "metadata": {},
+            "created_at": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+            "content": call_msg_assistant["content"],
+            "type": "ToolCallRequestEvent",
+        }
+
+        # 6️⃣ EXECUTION / result message
+        exec_payload = {
+            "content": (
+                f"✅ Activation complete – customer {customer_id}, "
+                f"phone {phone_number} is now live."
+            ),
+            "name": "activate_new_line_result_update",
+            "call_id": new_call_id,
+            "is_error": False,
+        }
+        exec_msg_assistant = {
+            "content": [exec_payload],
+            "type": "FunctionExecutionResultMessage",
+        }
+        exec_msg_thread = {
+            "id": str(uuid.uuid4()),
+            "source": "ai_assistant",
+            "models_usage": None,
+            "metadata": {},
+            "created_at": datetime.utcnow().isoformat(timespec="milliseconds") + "Z",
+            "content": [exec_payload],
+            "type": "ToolCallExecutionEvent",
+        }
+
+        # 7️⃣ Append to assistant LLM context  (keeps order)
+        ai_ctx.extend([call_msg_assistant, exec_msg_assistant])
+
+        # 8️⃣ Append to group-chat message thread
+        thread.extend([call_msg_thread, exec_msg_thread])
+
+        # 9️⃣ Persist updated state
+        __state_store__[__session_id__] = team_state
+    # kick off background task in a daemon thread
+    threading.Thread(
+        target=lambda: asyncio.run(_post_completion()),
+        daemon=True,
+    ).start()
+
+    # Immediate (first) response shown to the user
+    return (
+        "🔔 Background task scheduled. "
+        "Activation will take ~20 s; you will be notified once it is done."
+    )
+# ---------------------------------------------------------------------------
+class Agent(BaseAgent):  
+    def __init__(self, state_store, session_id) -> None:  
+        super().__init__(state_store, session_id)  
+        self.loop_agent = None  
+        self._initialized = False  
+  
+    async def _setup_loop_agent(self) -> None:  
+        """Initialize the assistant and tools once."""  
+        if self._initialized:  
+            return  
+  
+        server_params = StreamableHttpServerParams(  
+            url=self.mcp_server_uri,  
+            headers={"Content-Type": "application/json"},  
+            timeout=30  
+        )  
+  
+        # Fetch tools (async)  
+        tools = await mcp_server_tools(server_params)  
+
+        async def _activate_wrapper(customer_id: str, phone_number: str) -> str:
+            # Call internal helper with conversation context
+            return await _activate_new_line_impl(
+                customer_id,
+                phone_number,
+                __session_id__=self.session_id,
+                __state_store__=self.state_store,
+            )
+
+        # Copy metadata so AssistantAgent sees the right signature/docs
+        _activate_wrapper.__name__ = activate_new_line.__name__
+        _activate_wrapper.__doc__  = activate_new_line.__doc__
+        _activate_wrapper.__annotations__ = activate_new_line.__annotations__
+
+        tools.append(_activate_wrapper)     # AFTER tools = await mcp_server_tools()
+        # Set up the OpenAI/Azure model client  
+        model_client = AzureOpenAIChatCompletionClient(  
+            api_key=self.azure_openai_key,  
+            azure_endpoint=self.azure_openai_endpoint,  
+            api_version=self.api_version,  
+            azure_deployment=self.azure_deployment,  
+            model=self.openai_model_name,  
+        )  
+  
+        # Set up the assistant agent  
+        agent = AssistantAgent(  
+            name="ai_assistant",  
+            model_client=model_client,  
+            tools=tools,  
+            system_message=(  
+                "You are a helpful assistant. You can use multiple tools to find information and answer questions. "  
+                "Review the tools available to you and use them as needed. You can also ask clarifying questions if "  
+                "the user is not clear."  
+            )  
+        )  
+  
+        # Set the termination condition: stop when agent answers as itself  
+        termination_condition = TextMessageTermination("ai_assistant")  
+  
+        self.loop_agent = RoundRobinGroupChat(  
+            [agent],  
+            termination_condition=termination_condition,  
+        )  
+  
+        if self.state:  
+            await self.loop_agent.load_state(self.state)  
+        self._initialized = True  
+  
+    async def chat_async(self, prompt: str) -> str:  
+        """Ensure agent/tools are ready and process the prompt."""  
+        await self._setup_loop_agent()  
+  
+        response = await self.loop_agent.run(task=prompt, cancellation_token=CancellationToken())  
+        assistant_response = response.messages[-1].content  
+  
+        messages = [  
+            {"role": "user", "content": prompt},  
+            {"role": "assistant", "content": assistant_response}  
+        ]  
+        self.append_to_chat_history(messages)  
+  
+        # Update/store latest agent state  
+        new_state = await self.loop_agent.save_state()  
+        print(f"Updated state for session {self.session_id}: {new_state}")
+        self._setstate(new_state)  
+  
+        return assistant_response  

--- a/agentic_ai/applications/requirements.txt
+++ b/agentic_ai/applications/requirements.txt
@@ -5,8 +5,8 @@ tenacity==8.5.0
 openai==1.77.0  
 flasgger==0.9.7.1  
 fastmcp==2.7.1  
-autogen-ext[mcp]==0.6.4  
-autogen-agentchat==0.6.4  
+autogen-ext[mcp]==0.7.1  
+autogen-agentchat==0.7.1 
 uvicorn==0.34.3  
 fastapi==0.115.12  
 streamlit==1.45.0  

--- a/agentic_ai/applications/utils.py
+++ b/agentic_ai/applications/utils.py
@@ -144,8 +144,8 @@ class CosmosDBStateStore(abc.MutableMapping):
         return default if doc is None else doc["value"]  
   
     def __setitem__(self, session_id: str, value: Any) -> None:  
-        value = make_json_serializable(value)  # ensure JSON-serialisable
-        print("value after serialization:", value)  # Debugging line
+        # value = make_json_serializable(value)  # ensure JSON-serialisable
+        # print("value after serialization:", value)  # Debugging line
         self.container.upsert_item(  
             {  
                 "id": session_id,          # unique within a tenant  

--- a/agentic_ai/backend_services/Dockerfile.mcp
+++ b/agentic_ai/backend_services/Dockerfile.mcp
@@ -15,8 +15,8 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 # Copy the current directory contents into the container at /app  
 COPY . /app/  
   
-# Expose port 5000  
-EXPOSE 5000  
+# Expose port 8000 for the MCP service  
+EXPOSE 8000  
   
 # Run the Flask app with the host set to 0.0.0.0  
 CMD ["python", "mcp_service.py"]  

--- a/agentic_ai/backend_services/mcp_service.py
+++ b/agentic_ai/backend_services/mcp_service.py
@@ -12,9 +12,10 @@ mcp = FastMCP(
         "All customer, billing and knowledge data isaccessible ONLY via the declared "  
         "tools below.  Return values follow the pydanticschemas.  Always call the most "  
         "specific tool that answers the user’s question."  
-    ),  
-)  
-  
+    )
+) 
+# ─────────────────────────── CORS CONFIGURATION ─────────────────────────  
+
 # ─────────────────────────────  ENV & EMBEDDINGS  ───────────────────────  
 load_dotenv()  
 DB_PATH = os.getenv("DB_PATH", "data/contoso.db")  
@@ -598,4 +599,4 @@ def get_billing_summary(params: CustomerIdParam) -> Dict[str, Any]:
 #                                RUN SERVER                                  #  
 ##############################################################################  
 if __name__ == "__main__":  
-    asyncio.run(mcp.run_streamable_http_async(host="0.0.0.0", port=8000))  
+    asyncio.run(mcp.run_http_async(host="0.0.0.0", port=8000))  

--- a/agentic_ai/backend_services/requirements.txt
+++ b/agentic_ai/backend_services/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv==1.1.0
 tenacity==8.5.0  
 openai==1.77.0  
 flasgger==0.9.7.1  
-fastmcp==2.7.1  
-mcp==1.12.2  
-autogen-ext[mcp]==0.6.4  
-autogen-agentchat==0.6.4  
+fastmcp==2.11.0
+mcp==1.12.3 
+autogen-ext[mcp]==0.7.1  
+autogen-agentchat==0.7.1   


### PR DESCRIPTION
# Durable-Agent Demo 🚀  
  
> An experiment in making **AI agents durable** – i.e. able to  
> preserve state, survive crashes / restarts and handle long-running  
> workflows without blocking.  
  
---  
  
## 1.  Why “durable” agents?  
  
Normal conversational agents keep all their short-term memory **in RAM**.  
If the process dies, the whole context is lost.  Durable agents, in contrast, are designed to:  
  
1. **Persist state** – every turn they write their internal state to an external store (Cosmos DB in Azure or an in-memory dict for local runs).  
2. **Resume seamlessly** – on the next request they reload that state and continue the conversation exactly where they left off.  
3. **Survive long-running work** – they can kick off background jobs or remote orchestrations (Azure Durable Functions, workflows, etc.), go completely idle, and later integrate the result back into the conversation once it is available.  
  
These three abilities together make a durable agent *resilient*, *tolerant to infra hiccups*, and *suitable for complex, multi-step business flows*.  