### PR TITLE
ci(infra): apply per-environment tfvars via -var-file (fixes prod private topology)

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -82,8 +82,22 @@ jobs:
           export ARM_TENANT_ID="${{ vars.AZURE_TENANT_ID }}"
           export ARM_SUBSCRIPTION_ID="${{ vars.AZURE_SUBSCRIPTION_ID }}"
 
-          # Common -var flags used by plan and import
+          # Select the per-environment Terraform variable file. This is the
+          # single source of truth for networking, model deployments, and
+          # other env config (e.g. enable_networking / enable_private_endpoint).
+          #   production → prod.tfvars ; everything else → dev.tfvars
+          case "${{ inputs.environment }}" in
+            production|prod) VAR_FILE="prod.tfvars" ;;
+            *)               VAR_FILE="dev.tfvars" ;;
+          esac
+          echo "Using -var-file=${VAR_FILE} for environment '${{ inputs.environment }}'"
+
+          # -var-file is listed FIRST so the explicit -var flags below (env,
+          # subscription, location, ACR, images, iteration) override the
+          # matching keys from the tfvars file. Terraform applies -var/-var-file
+          # in command-line order, with later values winning.
           TF_VARS=(
+            -var-file=${VAR_FILE}
             -var project_name=${{ github.event.repository.name }}
             -var environment=${{ inputs.environment }}
             -var tenant_id=${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

Fixes a latent bug in the Terraform deploy step: it passed only individual `-var` flags and **never referenced `prod.tfvars` / `dev.tfvars`**, so `enable_networking` and `enable_private_endpoint` silently fell back to their **defaults (`false`)**. The pipeline therefore deployed a **public** topology even though both tfvars declare the intended **private** topology (VNet-integrated Container Apps env + Cosmos private endpoint, public access disabled).

## Why this matters (root cause of the prod `/chat` 500s)

Production ended up in a broken half-state:
- A manual `terraform apply -var-file=prod.tfvars` had set Cosmos `public_network_access` = **Disabled**, but
- the Container Apps **environment was created without VNet integration** (which is **immutable** post-creation), so the backend egresses over the **public internet** and Cosmos's firewall rejects it.

Result: every `/chat` returns **500** (`Forbidden ... blocked by your Cosmos DB account firewall settings`), which is what's failing `integration-tests` on PRs to `main` (e.g. #426) — even though those PRs don't touch the deployed backend.

## The change

Select the per-environment var file and pass it as `-var-file` (listed **before** the explicit `-var` flags so env/subscription/location/ACR/images/iteration still override the file):

```bash
case "<inputs.environment>" in
  production|prod) VAR_FILE="prod.tfvars" ;;
  *)               VAR_FILE="dev.tfvars" ;;
esac
TF_VARS=( -var-file=${VAR_FILE} -var project_name=... )
```

## ⚠️ Deployment impact (read before merging/deploying)

Applying this to an environment whose Container Apps env was created **without** a VNet will **force-replace that environment** (VNet integration is immutable), which **recreates the contained Container Apps** → brief backend/MCP **downtime**. This also creates the VNet/subnets and the Cosmos private endpoint. **Plan and redeploy during a maintenance window.**

Both `dev.tfvars` and `prod.tfvars` are internally consistent (`enable_networking=true` + `enable_private_endpoint=true`), so per-developer `integration-*` environments will likewise deploy the private topology on their next run.

## Related
- PR #428 (advisory integration tests) prevents this class of environmental breakage from blocking unrelated PRs to `main`.
