### PR TITLE
fix(infra): delegate Container Apps subnet + stop masking failed terraform apply (PROD RECOVERY)

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -124,7 +124,13 @@ jobs:
 
             terraform plan -out tfplan "${TF_VARS[@]}"
 
-            if terraform apply -auto-approve tfplan 2>&1 | tee /tmp/tf_apply.log; then
+            # Capture Terraform's exit code via PIPESTATUS — the pipe through
+            # `tee` otherwise reports tee's (success) status and masks a failed
+            # apply, which can leave the environment partially destroyed while
+            # the job reports success.
+            terraform apply -auto-approve tfplan 2>&1 | tee /tmp/tf_apply.log
+            apply_rc=${PIPESTATUS[0]}
+            if [ "$apply_rc" -eq 0 ]; then
               echo "✅ Terraform apply succeeded"
               break
             fi

--- a/infra/terraform/network.tf
+++ b/infra/terraform/network.tf
@@ -17,6 +17,17 @@ resource "azurerm_subnet" "container_apps" {
   resource_group_name  = azurerm_resource_group.rg.name
   virtual_network_name = azurerm_virtual_network.vnet[0].name
   address_prefixes     = [var.container_apps_subnet_prefix]
+
+  # Container App Environments require the infrastructure subnet to be
+  # delegated to Microsoft.App/environments, otherwise creation fails with
+  # ManagedEnvironmentSubnetDelegationError (400).
+  delegation {
+    name = "Microsoft.App.environments"
+    service_delegation {
+      name    = "Microsoft.App/environments"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/join/action"]
+    }
+  }
 }
 
 # Subnet for Private Endpoints


### PR DESCRIPTION
PRODUCTION RECOVERY for the outage caused by the #429 private-topology redeploy.

**Root causes**
1. The container_apps subnet lacked the required delegation, so the VNet-integrated Container Apps environment failed to create (ManagedEnvironmentSubnetDelegationError). The old env had already been destroyed -> no env, no apps.
2. The deploy step ran terraform apply | tee inside an if-condition without pipefail, so a failed apply reported success (tee's exit code) and masked the failure.

**Fixes**
- Add Microsoft.App/environments delegation to the container_apps subnet (network.tf).
- Capture terraform's real exit code via PIPESTATUS so a failed apply fails the job (infrastructure.yml).

Merging triggers a production redeploy that recreates the environment + apps with the corrected subnet delegation.